### PR TITLE
Remove ellipsis dependency

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^docs$
 
 [.]png$
+^tclust\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ README.Rmd
 
 # R Environment Variables
 .Renviron
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Provides functions for robust trimmed clustering. The methods are
     Fritz et al. (2012) <doi:10.18637/jss.v047.i12>, 
     Garcia-Escudero et al. (2011)  <doi:10.1007/s11222-010-9194-z> and others.
 Depends: R(>= 3.6.2)
-Imports: Rcpp (>= 1.0.7), doParallel, parallel, foreach, MASS, ellipsis
+Imports: Rcpp (>= 1.0.7), doParallel, parallel, foreach, MASS, rlang
 Suggests: mclust, cluster, sn
 LazyLoad: yes
 License: GPL-3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -16,7 +16,7 @@ importFrom("parallel", "detectCores", "makeCluster", "stopCluster")
 import("foreach", "foreach")
 import(doParallel)
 
-importFrom("ellipsis", "check_dots_used")
+importFrom("rlang", "check_dots_used")
 
 export(
     simula.rlg,

--- a/R/tclustIC.R
+++ b/R/tclustIC.R
@@ -115,14 +115,14 @@
 tclustIC <- function(x, kk=1:5, cc=c(1, 2, 4, 8, 16, 32, 64, 128), alpha=0.05, 
     whichIC=c("ALL", "MIXMIX", "MIXCLA", "CLACLA"), parallel=FALSE, n.cores=-1, trace=FALSE, ...) {
 
-    ## Check the ellipsis ...
+    ## Check the dots ...
     args <- list(...)
     if("opt" %in% names(args))
         stop("Argument 'opt' cannot be used with tclustIC()!")
     if("restr.fact" %in% names(args))
         stop("Argument 'restr.fact' cannot be used with tclustIC()!")
     
-    ellipsis::check_dots_used()
+    rlang::check_dots_used()
     
     whichIC <- match.arg(whichIC)
     if(trace) {


### PR DESCRIPTION
Since ellipsis is superseded + imports rlang

I ran R CMD CHECK cleanly on my machine, but I am getting an error

```r
  data (LG5data)
   x <- LG5data[, 1:10]
    clus <- rlg(x, d = c(2,2,2), alpha=0.1)
   plot(clus, which="eigenvalues") 
  #> Error in xy.coords(x, y, xlabel, ylabel, log) : 
   #>  'x' is a list, but does not have components 'x' and 'y'
 #> Calls: plot -> plot.default -> xy.coords
 #> Execution halted
```

